### PR TITLE
LOC-29 add a border-bottom change to a selected calendar slot in Calendar.jsx

### DIFF
--- a/src/components/profile/calendar/Calendar.jsx
+++ b/src/components/profile/calendar/Calendar.jsx
@@ -81,10 +81,20 @@ export default class Calendar extends React.Component {
             dateAfterDays.setDate(dateAfterDays.getDate() + afterDaysConst);
 
             let isPastDate = (new Date(value).getTime() < now.getTime()) || (new Date(value).getTime() > dateAfterDays);
+            let isSelected = value.toString() === this.props.selectedDate.toString();
+
+            let className = isPastDate ? 'date-in-past' : 'rbc-day-bg';
+            let borderBottom = isSelected ? '3px solid #d77961' : '1px solid #DDD';
 
             return (
-                <div className={isPastDate ? 'date-in-past' : 'rbc-day-bg'} style={{ flexBasis: 14.2857 + '%', maxWidth: 14.2857 + '%', cursor: 'auto' }}>
-                    {/* onClick={this.props.onSlotClick} */}
+                <div
+                    className={className}
+                    style={{
+                        flexBasis: 14.2857 + '%',
+                        maxWidth: 14.2857 + '%',
+                        cursor: 'auto',
+                        borderBottom
+                    }}>
                     {children}
                 </div>
             );

--- a/src/components/profile/calendar/CalendarPage.jsx
+++ b/src/components/profile/calendar/CalendarPage.jsx
@@ -186,13 +186,6 @@ class CalendarPage extends React.Component {
         this.componentDidMount();
     }
 
-    onSlotClick(e) {
-        if (document.getElementsByClassName('slot-selected').length > 0) {
-            document.getElementsByClassName('slot-selected')[0].className = '';
-        }
-        e.target.className = 'slot-selected';
-    }
-
     updateDailyPrice(captchaToken) {
         const listingId = this.props.match.params.id;
         const priceObj = {
@@ -235,8 +228,7 @@ class CalendarPage extends React.Component {
                             currencySign={this.state.currencySign}
                             // myListings={this.state.myListings}
                             selectedListing={this.state.selectedListing}
-                            onListingChange={this.onListingChange}
-                            onSlotClick={this.onSlotClick} />
+                            onListingChange={this.onListingChange} />
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
**What is this?**
The desired behavior when selecting a new date in Calendar.jsx is that an orange bottom border show up to let the user know the date was selected. Previously, this was being attempted with an onSlotClick() function to add a class that could be accessed and modified with CSS, but it was not working because the components.DateCellWrapper prop of Big Calendar was overwriting any css-level changes with React Style changes.

The solution was to introduce an isSelected boolean within the DateCell() function of Calendar.jsx and change the border properties at this level. Now the changes are not overwritten.